### PR TITLE
Fix missing prev/next icons, add them to settings

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -302,50 +302,40 @@ $slick-nav-dot: "\b7" !default;
   z-index: 1;
   height: $slick-arrow-size;
   width: round($slick-arrow-size * 0.75);
+  background: $slick-arrow-background;
+  opacity: 0.75;
 
   &:before {
-    font: normal normal normal 14px/1 FontAwesome;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    display: none;
+  }
+
+  svg {
     color: $slick-arrow-color;
-    font-size: $slick-arrow-size;
+    font-size: $slick-arrow-size * 0.6;
+  }
+
+  &:hover,
+  &:focus {
     background: $slick-arrow-background;
-    display: block;
+    opacity: 1;
   }
 }
 
 .slick-next {
   right: 0;
 
-  &:before {
-    content: $slick-arrow-next;
-  }
-
   [dir="rtl"] & {
     right: auto;
     left: 0;
-
-    &:before {
-      content: $slick-arrow-prev;
-    }
   }
 }
 
 .slick-prev {
   left: 0;
 
-  &:before {
-    content: $slick-arrow-prev;
-  }
-
   [dir="rtl"] & {
     right: 0;
     left: auto;
-
-    &:before {
-      content: $slick-arrow-next;
-    }
   }
 }
 

--- a/common/header.html
+++ b/common/header.html
@@ -8,6 +8,7 @@
 </script>
 
 <script type="text/discourse-plugin" version="0.8">
+const { iconHTML } = require("discourse-common/lib/icon-library");
 //------------------------------------------
 // I18n Translations
 //------------------------------------------
@@ -34,7 +35,9 @@ api.decorateCooked($elem =>
       slide: ".lightbox-wrapper",
       speed: 200,
       fade: true,
-      cssEase: "linear"
+      cssEase: "linear",
+      prevArrow: `<button type='button' class='slick-prev'>${iconHTML(settings.Slick_prev_icon)}</button>`,
+      nextArrow: `<button type='button' class='slick-next'>${iconHTML(settings.Slick_next_icon)}</button>`
     })
 );
 

--- a/settings.yml
+++ b/settings.yml
@@ -9,4 +9,12 @@ Slick_add_images_prompt:
 Slick_button_icon:
   default: "picture-o"
   description:
-    en: Choose an icon for the slick gallery button in the composer
+    en: Choose an icon for the slick gallery button in the composer.
+Slick_prev_icon:
+  default: "chevron-left"
+  description:
+    en: Choose an icon for the slick previous button.
+Slick_next_icon:
+  default: "chevron-right"
+  description:
+    en: Choose an icon for the slick next button.


### PR DESCRIPTION
@hnb-ku Another FontAwesome 5 PR. In this one, to make sure the icons are correctly registered, I exposed them in the component settings. 